### PR TITLE
Add vscode settings.json for workspace Tailwind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo
@@ -24,5 +25,3 @@ dist-ssr
 *.sln
 *.sw?
 
-# vscode
-.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-!.vscode/settings.json
 .idea
 .DS_Store
 *.suo
@@ -24,4 +21,3 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
-

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "files.associations": {
+    "*.css": "tailwindcss"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `.vscode/settings.json` with Tailwind CSS file association.
- Un-ignore `.vscode/settings.json` when it was gitignored so workspace editor settings are shared.

Related: https://linear.app/sanidhyy/issue/SAN-121/migrate-vscode-settingsjson

## Test plan
- [ ] Open the repo in the editor and confirm workspace TypeScript is offered (TypeScript repos)
- [ ] For Tailwind repos, confirm `*.css` is associated with Tailwind CSS